### PR TITLE
Bugfix on View::forge: improving the extensibility

### DIFF
--- a/views/admin/generation/basic/classes/controller/front.ctrl.php
+++ b/views/admin/generation/basic/classes/controller/front.ctrl.php
@@ -61,7 +61,7 @@ if (!empty($model['has_publishable_behaviour'])) {
 
         $<?= strtolower($model['name']) ?>_list =  Model_<?= $model['name'] ?>::find('all', $params);
 
-        return \View::forge('front/<?= strtolower($model['name']) ?>_list', array(
+        return \View::forge('<?= $data['application_settings']['folder'] ?>::front/<?= strtolower($model['name']) ?>_list', array(
             '<?= strtolower($model['name']) ?>_list' => $<?= strtolower($model['name']) ?>_list,
         ), false);
     }
@@ -91,7 +91,7 @@ if (!empty($model['has_publishable_behaviour'])) {
             )
         );
 
-        return \View::forge('front/<?= strtolower($model['name']) ?>_item', array(
+        return \View::forge('<?= $data['application_settings']['folder'] ?>::front/<?= strtolower($model['name']) ?>_item', array(
             '<?= strtolower($model['name']) ?>' => $<?= strtolower($model['name']) ?>,
         ), false);
     }


### PR DESCRIPTION
Hi,

View::forge is called without the application folder. It can prevent their extensibility, for instance if you create a view file in the local folder as specified in the documentation (http://docs.novius-os.org/en/elche/app_extend/extending.html#views), it won't work without this fix.

I hope everything is fine at Novius :)
