### PR TITLE
add application name for \View::forge

### DIFF
--- a/views/admin/generation/basic/classes/controller/front.ctrl.php
+++ b/views/admin/generation/basic/classes/controller/front.ctrl.php
@@ -61,7 +61,7 @@ if (!empty($model['has_publishable_behaviour'])) {
 
         $<?= strtolower($model['name']) ?>_list =  Model_<?= $model['name'] ?>::find('all', $params);
 
-        return \View::forge('front/<?= strtolower($model['name']) ?>_list', array(
+        return \View::forge('<?= $data['application_settings']['namespace'] ?>::front/<?= strtolower($model['name']) ?>_list', array(
             '<?= strtolower($model['name']) ?>_list' => $<?= strtolower($model['name']) ?>_list,
         ), false);
     }
@@ -91,7 +91,7 @@ if (!empty($model['has_publishable_behaviour'])) {
             )
         );
 
-        return \View::forge('front/<?= strtolower($model['name']) ?>_item', array(
+        return \View::forge('<?= $data['application_settings']['namespace'] ?>::front/<?= strtolower($model['name']) ?>_item', array(
             '<?= strtolower($model['name']) ?>' => $<?= strtolower($model['name']) ?>,
         ), false);
     }


### PR DESCRIPTION
Application name is necessary for \View::forge,
so that view overriding should work.
http://docs.novius-os.org/en/elche/app_extend/extending.html#views

This bus is found by @kenjis
