### PR TITLE
Remove "ON UPDATE CURRENT_TIMESTAMP"

### DIFF
--- a/views/admin/generation/basic/misc/model.sql.php
+++ b/views/admin/generation/basic/misc/model.sql.php
@@ -53,7 +53,7 @@ if (isset($model['has_author_behaviour'])) {
 
 ?>
     `<?= $model['column_prefix'] ?>created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
-    `<?= $model['column_prefix'] ?>updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `<?= $model['column_prefix'] ?>updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`<?= $model['column_prefix'] ?>id`),
     KEY `<?= $model['column_prefix'] ?>created_at` (`<?= $model['column_prefix'] ?>created_at`),
     KEY `<?= $model['column_prefix'] ?>updated_at` (`<?= $model['column_prefix'] ?>updated_at`)


### PR DESCRIPTION
As the Observer "Updated_At" will do the job, this instruction isn't required.
A "manual" SQL change would trigger it, whereas the observer has a more fonctionnal trigger.
