### PR TITLE
add index when a model is twinnable

### DIFF
--- a/views/admin/generation/basic/misc/model.sql.php
+++ b/views/admin/generation/basic/misc/model.sql.php
@@ -55,6 +55,11 @@ if (isset($model['has_author_behaviour'])) {
     `<?= $model['column_prefix'] ?>created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
     `<?= $model['column_prefix'] ?>updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`<?= $model['column_prefix'] ?>id`),
+<?php
+if (isset($model['has_twinnable_behaviour'])) {
+    echo '    KEY `' . $model['column_prefix'] . "context` (`". $model['column_prefix'] . "context_common_id`, `". $model['column_prefix'] . "context`),\n";
+}
+?>
     KEY `<?= $model['column_prefix'] ?>created_at` (`<?= $model['column_prefix'] ?>created_at`),
     KEY `<?= $model['column_prefix'] ?>updated_at` (`<?= $model['column_prefix'] ?>updated_at`)
 ) DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;


### PR DESCRIPTION
will produce

> KEY 'xxx_context' ('xxx_context_common_id',  'xxx_context'),
